### PR TITLE
[bootstrap_corenlp] no user mode

### DIFF
--- a/bootstrap_corenlp.sh
+++ b/bootstrap_corenlp.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 
-python3 -m pip install pexpect unidecode xmltodict jsonrpclib-pelix xmlrpclib --user
+USER_MODE="--user"
+if [ $# -eq 1 ] && [ $1 == "--nouser" ]
+then
+    echo "No user mode."
+    USER_MODE=""
+fi
+
+python3 -m pip install pexpect unidecode xmltodict jsonrpclib-pelix xmlrpclib $USER_MODE
 
 if [ ! -f corenlp-python ]
 then
@@ -9,7 +16,7 @@ then
 fi
 echo "Installing it…"
 cd corenlp-python
-python3 setup.py install --user
+python3 setup.py install $USER_MODE
 cd ..
 if [ ! -f stanford-corenlp-full-2014-08-27.zip ]
 then


### PR DESCRIPTION
Allow one to run the script `bootstrap_corenlp.sh` without user mode for the python install script.

Usefull since [travis does not accept user mode installations](https://travis-ci.org/ProjetPP/PPP-QuestionParsing-Grammatical/jobs/48377470#L198).