### PR TITLE
Fix request graph (applying @ProgVal's comments).

### DIFF
--- a/requests_graph.py
+++ b/requests_graph.py
@@ -49,7 +49,7 @@ parser.add_argument('-l', '--logger-url', type=str,
         default='http://logger.frontend.askplatyp.us/',
         help='The URL to the logger.')
 parser.add_argument('-c', '--cache-file-name', type=str,
-        default='requests_cache.json',
+        default=None,
         help='The name of the file used to cache data.')
 args = parser.parse_args()
 OUTPUT_FILE = args.outputfile
@@ -63,15 +63,16 @@ DATA_CACHE_FILENAME = args.cache_file_name
 fig, ax = plt.subplots()
 
 # Get data
-try:
+if DATA_CACHE_FILENAME is not None and os.path.isfile(DATA_CACHE_FILENAME):
     with open(DATA_CACHE_FILENAME) as data_cache:
         data = json.load(data_cache)
         print('Loaded the data from cache.')
-except FileNotFoundError:
+else:
     data = requests.get(LOGGER_URL, params={'limit': 10000}).json()
     print('Downloaded the data.')
-    with open(DATA_CACHE_FILENAME, 'w') as data_cache:
-        json.dump(data, data_cache)
+    if DATA_CACHE_FILENAME is not None:
+        with open(DATA_CACHE_FILENAME, 'w') as data_cache:
+            json.dump(data, data_cache)
 
 # Convert to datetime
 data = [datetime.datetime(*time.strptime(x[1].split('.')[0], "%Y-%m-%d %H:%M:%S")[:6]) for x in data]

--- a/requests_graph.py
+++ b/requests_graph.py
@@ -63,20 +63,15 @@ DATA_CACHE_FILENAME = args.cache_file_name
 fig, ax = plt.subplots()
 
 # Get data
-if os.path.isfile(LOGGER_URL):
-    file = open(LOGGER_URL, 'r')
-    data = json.load(file)
-    file.close()
-else:
-    try:
-        with open(DATA_CACHE_FILENAME) as data_cache:
-            data = json.load(data_cache)
-            print('Loaded the data from cache.')
-    except FileNotFoundError:
-        data = requests.get(LOGGER_URL, params={'limit': 10000}).json()
-        print('Downloaded the data.')
-        with open(DATA_CACHE_FILENAME, 'w') as data_cache:
-            json.dump(data, data_cache)
+try:
+    with open(DATA_CACHE_FILENAME) as data_cache:
+        data = json.load(data_cache)
+        print('Loaded the data from cache.')
+except FileNotFoundError:
+    data = requests.get(LOGGER_URL, params={'limit': 10000}).json()
+    print('Downloaded the data.')
+    with open(DATA_CACHE_FILENAME, 'w') as data_cache:
+        json.dump(data, data_cache)
 
 # Convert to datetime
 data = [datetime.datetime(*time.strptime(x[1].split('.')[0], "%Y-%m-%d %H:%M:%S")[:6]) for x in data]


### PR DESCRIPTION
The behavior is now the following:

``` bash
./requests_graph.py -g 1d -i 4w -t 3 plot.png -c cache.json
```

will load the data from `cache.json` if it exists, otherwise it will download the data from the logger and then store it in `cache.json`. Finally, it will draw the plot.

``` bash
./requests_graph.py -g 1d -i 4w -t 3 plot.png
```

will download the data from the logger and then draw the plot.

I am not sure it is a good idea to make the cache expire after some time.
Currently, we can download the data once and then work on it without internet connection. With cache expiration, it would be impossible, since the script would automatically try to re-download the data after some time.
